### PR TITLE
Update Dockerfile to copy EMDK JAR directly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,8 +82,7 @@ WORKDIR /workspace
 # Copy project files
 COPY . /workspace
 
-# Create directory for optional libraries
-RUN mkdir -p /usr/lib/android-sdk/platforms/android-28/optional/
-
-# Copy EMDK .jar file into the optional directory
-COPY libs/com.symbol.emdk.jar /usr/lib/android-sdk/platforms/android-28/optional/
+# Install Symbol.XamarinEMDK package and extract JAR
+RUN dotnet nuget install Symbol.XamarinEMDK -OutputDirectory /tmp/emdk \
+    && mkdir -p /usr/lib/android-sdk/platforms/android-28/optional/ \
+    && find /tmp/emdk -name com.symbol.emdk.jar -exec cp {} /usr/lib/android-sdk/platforms/android-28/optional/ \;


### PR DESCRIPTION
## Summary
- copy `com.symbol.emdk.jar` from the Symbol.XamarinEMDK package directly to the Android SDK optional directory

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684f9b6e23f8832980fc2e6ee896e137